### PR TITLE
Parse meta data in headers more consistently

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ st.getMeta = function(label) {
 			});
 		}
 		else {
-			description = kv_parts.shift;
+			description = kv_parts.shift();
 		}
 	}
 	

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,54 +9,114 @@
 var st = {};
 module.exports = st;
 
+/****
+ * Seems to be lots of different ways to format FASTA headers. 
+ * 
+ * Generally there's an ID and a DESCRIPTION
+ *   >ID DESCRIPTION
+ * 
+ *   >(parts|of|ID) (DESCRIPTION with optional key=values)
+ *   
+ * This is complicated by the fact that the "values" in the description can have spaces
+ * e.g. OS=Arabidopsis thaliana GN=CCD8
+ * 
+ ****
+*/
+
 // extract IDs and push them to the meta dict
 st.getMeta = function(label) {
-  if (st.contains(label, "|")) {
-    var identifiers = label.split("|");
-    var k = 0;
-    var database, databaseID;
-    var meta = {};
-    while (k < identifiers.length - 1) {
-      database = identifiers[k];
-      databaseID = identifiers[k + 1];
-      meta[database] = databaseID;
-      k += 2;
-    }
-    // assume the last entry is the label
-    var name = identifiers[identifiers.length - 1];
-    // check whether there is a uniprot id
-    if (name.indexOf("=") >= 0 && name.indexOf("OS") >= 0) {
-      var ds = {};
-      var details = name.split(" ");
-      ds.en = details[0];
-      details = details.splice(1);
-      var nameLength = findSepInArr(details, "=");
-      var detailsTmp = details.splice(nameLength - 1);
-      name = details.join(" ");
-      details = detailsTmp;
-      k = 0;
-      var block = [];
-      details.forEach(function(item) {
-        block.push(item);
-        if (item.indexOf("=") >= 0) {
-          strToDict(block.join(" "), "=", ds);
-          block = [];
-        }
-      });
-      return {
-        name: name,
-        ids: meta,
-        details: ds
-      };
-    }
-    return {
-      name: name,
-      ids: meta
-    };
-  }
-  return {
-    name: label
-  };
+  
+	var full_id = false, full_desc = false;
+	var name, ids = {}, details = {}, description;
+
+// 	console.log( "getMeta.label: ", label );
+  
+	var label_parts = label.split(" ");
+
+	if ( label_parts.length >= 1 ) {
+		full_id   = label_parts.shift();     // everything up to the first white space
+		full_desc = label_parts.join(" ");   // everything else
+	}
+	else {
+		full_id = label; 
+	}
+	
+// 	console.log( "full_id", full_id );
+// 	console.log( "full_desc", full_desc );
+	
+	if ( full_id ) {
+		var id_parts = full_id.split('|');
+		
+		// the last item is the accession
+		name = id_parts.pop(); 
+		
+		details.en = name;
+		
+		// everything else should be pairs: db|id
+		while ( id_parts.length != 0 ) {
+			var db = id_parts.shift();
+			var id = id_parts.shift();
+			ids[ db ] = id;
+		}
+	}
+	else {
+		name = full_id;
+	}
+
+	if ( full_desc ) {
+	
+		var kv_parts = full_desc.split('=');
+	
+		if ( kv_parts.length > 1 ) {
+			
+			var current_key, next_key;
+			var kv;
+			var kv_idx_max = kv_parts.length - 1;
+			var kv_idx = 0;
+			kv_parts.forEach( function( value_and_maybe_next_key ) {
+				
+				value_and_maybe_next_key = value_and_maybe_next_key.trim();
+				
+				var value_parts = value_and_maybe_next_key.split(" ");
+				var value;
+				if ( value_parts.length > 1 ) {
+					next_key = value_parts.pop();
+					value = value_parts.join(' ');
+				}
+				else {
+					value = value_and_maybe_next_key;
+				}
+
+				if ( current_key ) {
+					var key = current_key.toLowerCase();
+					details[ key ] = value;
+					//console.log( "details[" + key + "] = " + value );
+				}
+				else {
+					description = value;
+					//console.log( "description=" + value );
+				}
+				current_key = next_key;
+			});
+		}
+		else {
+			description = kv_parts.shift;
+		}
+	}
+	
+	var meta = {
+		name: name,
+		ids: ids,
+		details: details,
+	};
+	
+	if ( description ) {
+		meta.desc = description
+	}
+	
+// 	console.log( "meta", meta );
+	
+	return meta;
 };
 
 var findSepInArr = function(arr, sep) {

--- a/test/test_seqtools.js
+++ b/test/test_seqtools.js
@@ -59,6 +59,19 @@ describe('msa-seqtools module', function() {
         }
       });
     });
+    it('correctly parse descriptions without key=value', function() {
+      equal(st.getMeta("sp|abc|def a long description with no key values"), {
+        name: "def",
+        ids: {
+          sp: "abc"
+        },
+        details: {
+          en: "def"
+        },
+        desc: "a long description with no key values"
+      });
+    });
+	
   });
   describe('#buildLinks()', function() {
     it('should show correct links', function() {

--- a/test/test_seqtools.js
+++ b/test/test_seqtools.js
@@ -24,17 +24,37 @@ describe('msa-seqtools module', function() {
         ids: {
           sp: "abc"
         },
+        details: {
+          en: "def"
+        }
       });
     });
-    it('should should recognize uniprot', function() {
+    it('should should recognize key=value', function() {
       equal(st.getMeta("sp|abc|def a long description OS=organism GN=genename"), {
-        name: "a long description",
+        name: "def",
         ids: {
           sp: "abc"
         },
         details: {
           os: "organism",
           gn: "genename",
+          en: "def"
+        },
+        desc: "a long description"
+      });
+    });
+    it('should deal with spaces in key=value', function() {
+      equal(st.getMeta("sp|abc|def Carotenoid cleavage dioxygenase 8, chloroplastic OS=Arabidopsis thaliana GN=CCD8 PE=1 SV=1 "), {
+        name: "def",
+        desc: "Carotenoid cleavage dioxygenase 8, chloroplastic",
+        ids: {
+          sp: "abc"
+        },
+        details: {
+          os: "Arabidopsis thaliana",
+          gn: "CCD8",
+          pe: "1",
+          sv: "1",
           en: "def"
         }
       });


### PR DESCRIPTION
This is a rewrite of the getMeta() to take into account what look like inconsistencies and to hopefully add extra useful information (separating name into name + long description). I've added a couple of tests, but it would be great to include some more to make sure this changeset doesn't break anything.

NOTE: this includes minor changes to the existing tests, so there may be some potential knock-on effects upstream. Please check carefully before accepting.

**Issue: UniProt key=value descriptions can contain spaces**

e.g.

`OS=Homo sapiens`

(added test and fixed)

**Feature: the 'name' is now separated into the accession and an (optional) description**

e.g

`sp|abc|accession a long description OS=organism GN=genename`

was:

```
{
  name: "accession a long description",
  ids: { sp: "abc" },
  details: { os: "organism", gn: "genename", en: "accession" }
}
```

now:

```
{
  name: "accession",
  desc: "a long description",
  ids: { sp: "abc" },
  details: { os: "organism", gn: "genename", en: "def" }
}
```
